### PR TITLE
feat: tab saves slider textbox input

### DIFF
--- a/rope/GUIElements.py
+++ b/rope/GUIElements.py
@@ -853,6 +853,7 @@ class Slider2():
         self.entry = tk.Entry(self.frame, self.entry_style, textvariable=self.entry_string)
         self.entry.place(x=self.entry_x, y=self.entry_y)
         self.entry.bind('<Return>', lambda event: self.entry_input(event))
+        self.entry.bind('<Tab>', lambda event: self.entry_input(event))
 
         # Draw the slider
         self.slider_pad = 20


### PR DESCRIPTION
Says what it does on the box.

I'm lazy, when I need to edit multiple values through the textbox inputs of sliders I don't want to have to press Enter after each value, when I use the `Tab` key it should save that value. It also avoids an odd desync between the Slider effective value and the displaye value in the textbox if I forget to press Enter.