### PR TITLE
fix: utf-8 image filename support

### DIFF
--- a/rope/GUI.py
+++ b/rope/GUI.py
@@ -2325,7 +2325,7 @@ class GUI(tk.Tk):
             else:
                 # Its an image
                 if file_type == 'image':
-                    img = cv2.imread(file)
+                    img = cv2.imdecode(np.fromfile(file, dtype=np.uint8), cv2.IMREAD_UNCHANGED)
 
                     if img is not None:
                         img = torch.from_numpy(img.astype('uint8')).to('cuda')
@@ -2626,7 +2626,7 @@ class GUI(tk.Tk):
                 # Its an image
                 if file_type == 'image':
                     try:
-                        image = cv2.imread(file)
+                        image = cv2.imdecode(np.fromfile(file, dtype=np.uint8), cv2.IMREAD_UNCHANGED)
                         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
                     except:
                         print('Trouble reading file:', file)

--- a/rope/VideoManager.py
+++ b/rope/VideoManager.py
@@ -233,7 +233,7 @@ class VideoManager():
         self.frame_q = []
         self.r_frame_q = []
         self.found_faces = []
-        self.image = cv2.imread(file) # BGR
+        self.image = cv2.imdecode(np.fromfile(file, dtype=np.uint8), cv2.IMREAD_UNCHANGED) # BGR
         self.image = cv2.cvtColor(self.image, cv2.COLOR_BGR2RGB) # RGB
         temp = [self.image, False]
         self.frame_q.append(temp)


### PR DESCRIPTION
When you attempt to load faces images or paths with special characters you get this kind of errors du to OpenCV's `imread` not supporting these natively (low chances to get this fixed upstream though): 

```
[ WARN:0@2488.154] global loadsave.cpp:241 cv::findDecoder imread_('C:/B├╝cher\image.jpg'): can't open/read file: check file path/integrit
```

We can work around this by using `np.fromfile` which support UTF-8 paths and pass the binary content to OpenCV's `imdecode`.

